### PR TITLE
Remove hood location from JSON

### DIFF
--- a/index.php
+++ b/index.php
@@ -91,7 +91,6 @@ $json['vpn'] = getAllVPNs($hood['ID']);
 unset($hood['ID']);
 unset($hood['prefix']);
 
-$hood['location'] = array('lat' => $hood['lat'], 'lon' => $hood['lon']);
 unset($hood['lat']);
 unset($hood['lon']);
 


### PR DESCRIPTION
Not every hood has a location, so it is not sensible to include it
in the hood file. This is most obvious for local hoods, which are
supposed to work without a specific position.

Thus, just remove the location, which is not used, instead of
faking it for the polygon hoods.

Signed-off-by: Adrian Schmutzler <adrian.schmutzler@uni-bayreuth.de>